### PR TITLE
Improve AMS usage detection

### DIFF
--- a/bambu_spoolman/broker/filament_usage_tracker.py
+++ b/bambu_spoolman/broker/filament_usage_tracker.py
@@ -87,7 +87,7 @@ class FilamentUsageTracker:
 
         self.ams_mapping = print_obj.get("ams_mapping", [])
         if print_obj.get("use_ams", False) \
-            or (len(self.ams_mapping) == 1 and self.ams_mapping[0] not in (-1, 255)):
+            or (self.ams_mapping and self.ams_mapping[0] not in (-1, 255)):
             logger.info("Using AMS")
             self.using_ams = True
             logger.info("AMS mapping: {}", self.ams_mapping)


### PR DESCRIPTION
When starting prints from the printer, `use_ams` is not present in mqtt messages.

To work around this, add a check using `ams_mapping`. If the array isnt empty, and the first element is `-1` or `255` then we are using the external spool and not the AMS.

From the conversation in #6 