### PR TITLE
Fix QRCode is now Case insensitiv

### DIFF
--- a/frontend/src/components/models/SpoolChangeModel.tsx
+++ b/frontend/src/components/models/SpoolChangeModel.tsx
@@ -137,8 +137,8 @@ function QrCodeButtonWrapper() {
   return <QrCodeButton />;
 }
 
-const urlRegex = /https?:\/\/.*\/(\d+)/;
-const spoolmanRegex = /web\+spoolman:s-(\d+)/;
+const urlRegex = /https?:\/\/.*\/(\d+)/i;
+const spoolmanRegex = /web\+spoolman:s-(\d+)/i;
 
 export default function SpoolChangeModel(props: FilamentChangeModelProps) {
   const { close } = usePopup();


### PR DESCRIPTION
Default Spoolman QRCode is 
WEB+SPOOLMAN:S-{id}
but the regex was not insensitiv