### PR TITLE
fix: show fill of spool visually on home page

### DIFF
--- a/frontend/components/AmsTray.tsx
+++ b/frontend/components/AmsTray.tsx
@@ -24,7 +24,7 @@ async function InnerAmsTray({ id }: Props) {
 
   return (
     <Link href={`/ams/${Math.floor(id / 4) + 1}/tray/${(id % 4) + 1}`}>
-      <SpoolChip spool={spool} size="large" />
+      <SpoolChip spool={spool} size="large" withPercentage />
       {material && <div className="text-center">{material}</div>}
     </Link>
   );


### PR DESCRIPTION
In previous releases, the slotted spools would visually show how empty/full they are. It still does that when swapping spools but not on the homepage anymore. This simple fix should bring that back.