### PR TITLE
Added cache backup path for P2S

### DIFF
--- a/bambu_spoolman/broker/filament_usage_tracker.py
+++ b/bambu_spoolman/broker/filament_usage_tracker.py
@@ -257,9 +257,14 @@ class FilamentUsageTracker:
             if model_path.startswith(p):
                 model_path = model_path.removeprefix(p)
                 break
-
-        # Retrieve from FTP server
-        return retrieve_3mf(model_path)
+        # P2S exposes eMMC under /cache/ instead of /emmc/
+        if model_path.startswith("emmc/"):
+            result = retrieve_3mf(model_path)  # Try original path first (older printers)
+            if result is None:
+                logger.debug("eMMC path failed, retrying as cache/ (P2S fallback)")
+                model_path = "cache/" + model_path.removeprefix("emmc/")
+                return retrieve_3mf(model_path)
+            return result
 
     def _load_model(self, model_path, gcode_file):
         gcode = extract_gcode(model_path, gcode_file)


### PR DESCRIPTION
The printer P2S does not expose eMMC. Need to use a USB drive and use the cache path to fetch print.