### PR TITLE
Implement cache fallback for P2S

### DIFF
--- a/bambu_spoolman/broker/filament_usage_tracker.py
+++ b/bambu_spoolman/broker/filament_usage_tracker.py
@@ -257,9 +257,14 @@ class FilamentUsageTracker:
             if model_path.startswith(p):
                 model_path = model_path.removeprefix(p)
                 break
-
-        # Retrieve from FTP server
-        return retrieve_3mf(model_path)
+        # P2S exposes eMMC under /cache/ instead of /emmc/
+        if model_path.startswith("emmc/"):
+            result = retrieve_3mf(model_path)  # Try original path first (older printers)
+            if result is None:
+                logger.debug("eMMC path failed, retrying as cache/ (P2S fallback)")
+                model_path = "cache/" + model_path.removeprefix("emmc/")
+                return retrieve_3mf(model_path)
+            return result
 
     def _load_model(self, model_path, gcode_file):
         gcode = extract_gcode(model_path, gcode_file)

--- a/bambu_spoolman/broker/filament_usage_tracker.py
+++ b/bambu_spoolman/broker/filament_usage_tracker.py
@@ -257,14 +257,14 @@ class FilamentUsageTracker:
             if model_path.startswith(p):
                 model_path = model_path.removeprefix(p)
                 break
-        # P2S exposes eMMC under /cache/ instead of /emmc/
-        if model_path.startswith("emmc/"):
-            result = retrieve_3mf(model_path)  # Try original path first (older printers)
-            if result is None:
-                logger.debug("eMMC path failed, retrying as cache/ (P2S fallback)")
-                model_path = "cache/" + model_path.removeprefix("emmc/")
-                return retrieve_3mf(model_path)
-            return result
+                
+        result = retrieve_3mf(model_path)  # Try original path first (older printers)
+        if result is None:
+            # USB storage backup for P2S printers
+            logger.debug("eMMC path failed, retrying as cache/ (P2S fallback)")
+            model_path = "cache/" + model_path.removeprefix("emmc/")
+            return retrieve_3mf(model_path)
+        return result
 
     def _load_model(self, model_path, gcode_file):
         gcode = extract_gcode(model_path, gcode_file)


### PR DESCRIPTION
Add fallback to retrieve model from USB cache if eMMC path fails.
For the P2S the eMMC folder is not exposed to FTP, so the file has to be fetched from USB storage.